### PR TITLE
22 - Add Owner Permission on Upload

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/pojos/DelegatePermissionParams.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/pojos/DelegatePermissionParams.java
@@ -4,18 +4,33 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
+// TODO add a permission time limit param
 public class DelegatePermissionParams {
 
     private DocumentPermission permission;
-    private String clientId;
+    private int userId;
     private boolean canPropogate;
+
+    @SuppressWarnings("unused")
+    // this default is required for Jackson
+    public DelegatePermissionParams() {}
+
+    public DelegatePermissionParams(
+            DocumentPermission permission,
+            int userId,
+            boolean canPropogate) {
+
+        this.permission = permission;
+        this.userId = userId;
+        this.canPropogate = canPropogate;
+    }
 
     public DocumentPermission getPermission() {
         return permission;
     }
 
-    public String getClientId() {
-        return clientId;
+    public int getUserId() {
+        return userId;
     }
 
     public boolean getCanPropogate() {

--- a/src/main/java/com/cs6238/project2/s2dr/server/services/DocumentService.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/services/DocumentService.java
@@ -5,6 +5,7 @@ import com.cs6238.project2.s2dr.server.exceptions.DocumentNotFoundException;
 import com.cs6238.project2.s2dr.server.exceptions.UnexpectedQueryResultsException;
 import com.cs6238.project2.s2dr.server.pojos.DelegatePermissionParams;
 import com.cs6238.project2.s2dr.server.pojos.DocumentDownload;
+import com.cs6238.project2.s2dr.server.pojos.DocumentPermission;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +44,18 @@ public class DocumentService {
     public int uploadDocument(File document, String documentName, String securityFlag)
             throws SQLException, FileNotFoundException, UnexpectedQueryResultsException {
 
-        return documentDao.uploadDocument(document, documentName, securityFlag);
+        int documentId = documentDao.uploadDocument(document, documentName, securityFlag);
+
+        // TODO once we add a user session (login), we will have access to the "currentUserId"
+        // TODO without making a query. For now the name is just hardcoded in.
+        int currentUserId = documentDao.getUserIdByName("Puckett, Michael");
+
+        // when a user uploads a new document, we add an "Owner" permission for that user.
+        // TODO once we add the "time" parameter, this should add an "unlimited" time for the uploader
+        documentDao.delegatePermissions(documentId,
+                new DelegatePermissionParams(DocumentPermission.OWNER, currentUserId, true));
+
+        return documentId;
     }
 
     public DocumentDownload downloadDocument(int documentId)

--- a/src/main/resources/s2dr.sql
+++ b/src/main/resources/s2dr.sql
@@ -32,11 +32,11 @@ CREATE TABLE s2dr.Documents
 CREATE TABLE s2dr.DocumentPermissions
 (
   documentId INT NOT NULL,
-  clientId VARCHAR (255) NOT NULL,
+  userId INT NOT NULL,
   permission VARCHAR (5) NOT NULL,
   canPropogate VARCHAR(5) NOT NULL,
   FOREIGN KEY (documentId) REFERENCES s2dr.Documents(documentId),
-  FOREIGN KEY (clientId) REFERENCES s2dr.Users(userId)
+  FOREIGN KEY (userId) REFERENCES s2dr.Users(userId)
 );
 -- TODO constrain DocumentPermissions.permission to be only "READ", "WRITE", "BOTH", or "OWNER"
 -- TODO constrain DocumentPermissions.canPropogate to be only "Y" or "N"


### PR DESCRIPTION
- When a user uploads a document, we now automatically add an OWNER
  permission for that user so that it can be checked later. I also
  changed the `VAR CHAR` `DocumentPermissions.clientId` client to an `INT`
  `DocumentPermissions.userId` column.

Fixes #22