### PR TITLE
25 Fix H2 Server Thread

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/guice/GuiceServletConfig.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/guice/GuiceServletConfig.java
@@ -3,10 +3,10 @@ package com.cs6238.project2.s2dr.server.guice;
 import com.cs6238.project2.s2dr.server.services.DocumentService;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Singleton;
 import com.google.inject.Stage;
 import com.google.inject.servlet.GuiceServletContextListener;
 import com.google.inject.servlet.ServletModule;
-import org.h2.tools.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +18,6 @@ public class GuiceServletConfig extends GuiceServletContextListener {
 
     public static Injector injector;
     private static final Logger LOG = LoggerFactory.getLogger(DatabaseModule.class);
-    private Thread thread;
 
     @Override
     protected Injector getInjector() {
@@ -32,36 +31,38 @@ public class GuiceServletConfig extends GuiceServletContextListener {
                         // that are injected into non Jersey-configured classes
                         // will not require this
                         bind(DocumentService.class);
+
+                        bind(H2ServerRunner.class).in(Singleton.class);
                     }
                 },
                 new DatabaseModule());
 
         return injector;
     }
-//    @Override
-//    public void contextInitialized(ServletContextEvent servletContextEvent){
-//        super.contextInitialized(servletContextEvent);
-//        try {
-//            final Connection conn = injector.getInstance(Connection.class);
-//            thread = new Thread(){
-//                public void run() {
-//                    try {
-//                        Server.startWebServer(conn);
-//                    } catch (SQLException e) {
-//                        LOG.debug("Server Not Starting");
-//                    }
-//                }
-//            };
-//            thread.start();
-//        } finally {
-//            LOG.debug("Exiting H2 server.");
-//        }
-//    }
-//
-//    @Override
-//    public void contextDestroyed( ServletContextEvent servletContextEvent){
-//        thread.stop();
-//        super.contextDestroyed(servletContextEvent);
-//
-//    }
+    
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent){
+        super.contextInitialized(servletContextEvent);
+
+        H2ServerRunner runner = injector.getInstance(H2ServerRunner.class);
+        runner.startAsync();
+    }
+
+    @Override
+    public void contextDestroyed( ServletContextEvent servletContextEvent){
+        super.contextDestroyed(servletContextEvent);
+
+        // close the database connection
+        Connection conn = injector.getInstance(Connection.class);
+        try {
+            conn.close();
+        } catch (SQLException e) {
+            LOG.error("Unable to close the database connection");
+        }
+
+        // the connection should be shut down first
+        H2ServerRunner runner = injector.getInstance(H2ServerRunner.class);
+        runner.triggerShutdown();
+        runner.stopAsync();
+    }
 }

--- a/src/main/java/com/cs6238/project2/s2dr/server/guice/H2ServerRunner.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/guice/H2ServerRunner.java
@@ -1,0 +1,48 @@
+package com.cs6238.project2.s2dr.server.guice;
+
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import org.h2.tools.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.sql.Connection;
+
+public class H2ServerRunner extends AbstractExecutionThreadService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(H2ServerRunner.class);
+
+    private final Connection connection;
+
+    boolean isRunning = false;
+
+    @Inject
+    public H2ServerRunner(Connection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    protected void startUp() {
+        try {
+            Server.startWebServer(connection);
+            isRunning = true;
+            this.run();
+        } catch (Exception e) {
+            isRunning = false;
+            LOG.error("Unable to start the H2 web server. {}", e);
+        }
+    }
+
+    @Override
+    protected void run() throws Exception {
+        while (isRunning && !connection.isClosed()) {
+            isRunning = true;
+        }
+    }
+
+    @Override
+    protected void triggerShutdown() {
+        isRunning = false;
+    }
+}
+


### PR DESCRIPTION
- This uses Guava's `AbstractExecutionThreadService` to run the H2
  Server in a seperate thread, and allows a clean way to shut the thread
  down when the servlet context is destroyed. I tested that the thread
  was being shutdown properly by starting and stopping the servlet
  several times and running `ps aux | grep java` in between each
  instance to make sure that there weren't new processes being spawned.

Fixes #25