### PR TITLE
26 - Fix Document Delete

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/dao/DocumentDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/dao/DocumentDao.java
@@ -278,4 +278,22 @@ public class DocumentDao {
             }
         }
     }
+
+    public void deleteAllDocumentPermissions(int documentId) throws SQLException {
+        String query =
+                "DELETE" +
+                "  FROM s2dr.DocumentPermissions" +
+                " WHERE documentId = ?";
+
+        PreparedStatement ps = null;
+        try {
+            ps = conn.prepareStatement(query);
+            ps.setInt(1, documentId);
+            ps.executeUpdate();
+        } finally {
+            if (ps != null) {
+                ps.close();
+            }
+        }
+    }
 }

--- a/src/main/java/com/cs6238/project2/s2dr/server/services/DocumentService.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/services/DocumentService.java
@@ -69,6 +69,12 @@ public class DocumentService {
     }
 
     public void deleteDocument(int documentId) throws SQLException {
+
+        // delete all permissions for the document before deleting the document
+        LOG.info("Deleting all permissions for document: {}", documentId);
+        documentDao.deleteAllDocumentPermissions(documentId);
+
+        LOG.info("Performing safe delete on document: {}", documentId);
         documentDao.deleteDocument(documentId);
     }
 }

--- a/src/main/java/com/cs6238/project2/s2dr/server/web/RestEndpoint.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/web/RestEndpoint.java
@@ -121,7 +121,7 @@ public class RestEndpoint {
     @Path("/document/{documentId}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response deleteDocument(@PathParam("documentId") int documentId) throws SQLException{
-        LOG.info("Deleting document: {}", documentId);
+        LOG.info("Received request to delete document: {}", documentId);
         documentService.deleteDocument(documentId);
 
         // return 200


### PR DESCRIPTION
- If there was an entry in the `DocumentPermissions` table for a
  particular document, a `SqlException` was thrown when attempting to
  delete the document. This was because `DocumentPermissions.documentId`
  was a foreign key to `Documents.documentId`. This deletes all
  permissions for a document before deleting the document.