### PR TITLE
7 - Add HTTPS and Login/Logout Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ gretty {
     port = 8080
     contextPath = '/'
     servletContainer = 'tomcat8'
+
+    httpsEnabled = true
 }
 
 repositories {
@@ -29,12 +31,11 @@ dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.3'
     compile 'ch.qos.logback:logback-core:1.1.3'
 
-    // RESTful API libraries
+    // Jersey used to build our RESTful API
     compile 'org.glassfish.jersey.core:jersey-server:2.22.1'
     compile 'org.glassfish.jersey.core:jersey-client:2.22.1'
     compile 'org.glassfish.jersey.media:jersey-media-multipart:2.22.1'
     compile 'org.glassfish.jersey.containers:jersey-container-servlet:2.22.1'
-
     compile 'org.glassfish.hk2:guice-bridge:2.3.0'
 
     compile 'javax.servlet:javax.servlet-api:3.1.0'
@@ -44,9 +45,23 @@ dependencies {
     compile 'com.fasterxml.jackson.module:jackson-module-guice:2.6.3'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.3'
 
-    // guice for DI
+    // guice for DI and servlet configuration
     compile 'com.google.inject:guice:4.0'
+    compile 'com.google.inject.extensions:guice-multibindings:4.0'
     compile 'com.google.inject.extensions:guice-servlet:4.0'
+
+    // apache shiro used for authentication and session management
+    compile 'org.apache.shiro:shiro-core:1.2.4'
+    compile 'org.apache.shiro:shiro-web:1.2.4'
+    compile 'org.apache.shiro:shiro-guice:1.2.4'
+
+    // logging dependencies needed by shiro
+    // TODO figure out how to exclude these dependencies
+    compile 'org.apache.logging.log4j:log4j-core:2.1'
+    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.1'
+    compile 'org.apache.logging.log4j:log4j-jul:2.1'
+    compile 'org.apache.logging.log4j:log4j-1.2-api:2.1'
+    compile 'org.apache.logging.log4j:log4j-jcl:2.1'
 
     // guava to improve general Java
     compile 'com.google.guava:guava:18.0'

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/RestEndpoint.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/RestEndpoint.java
@@ -4,13 +4,24 @@ import com.cs6238.project2.s2dr.server.app.exceptions.DocumentNotFoundException;
 import com.cs6238.project2.s2dr.server.app.exceptions.UnexpectedQueryResultsException;
 import com.cs6238.project2.s2dr.server.app.objects.DelegatePermissionParams;
 import com.cs6238.project2.s2dr.server.app.objects.DocumentDownload;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.subject.Subject;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.File;
@@ -49,6 +60,21 @@ public class RestEndpoint {
 
         LOG.info("Getting personal hello message for userId: {}", userId);
         return documentService.getHelloMessage(Optional.ofNullable(userId));
+    }
+
+    @POST
+    @Path("/login")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response login(@FormDataParam("username") String username,
+                          @FormDataParam("password") String password) {
+
+        Subject currentUser = SecurityUtils.getSubject();
+
+        // this will throw an exception if login fails
+        currentUser.login(new UsernamePasswordToken(username, password));
+
+        return Response.ok().build();
     }
 
     @POST
@@ -124,6 +150,16 @@ public class RestEndpoint {
         documentService.deleteDocument(documentId);
 
         // return 200
+        return Response.ok().build();
+    }
+
+    @POST
+    @Path("/logout")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response logout() {
+        Subject currentUser = SecurityUtils.getSubject();
+        currentUser.logout();
+
         return Response.ok().build();
     }
 }

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/User.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/User.java
@@ -1,0 +1,99 @@
+package com.cs6238.project2.s2dr.server.app.objects;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
+public class User {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int userId;
+        private String firstName;
+        private String lastName;
+        private String userName;
+
+        public Builder setUserId(int userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder setFirstName(String firstName) {
+            this.firstName = firstName;
+            return this;
+        }
+
+        public Builder setLastName(String lastName) {
+            this.lastName = lastName;
+            return this;
+        }
+
+        public Builder setUserName(String userName) {
+            this.userName = userName;
+            return this;
+        }
+
+        public User build() {
+            return new User(
+                    userId,
+                    firstName,
+                    lastName,
+                    userName);
+        }
+    }
+
+    private final int userId;
+    private final String firstName;
+    private final String lastName;
+    private final String userName;
+
+    private User(
+            int userId,
+            String firstName,
+            String lastName,
+            String userName) {
+
+        this.userId = userId;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.userName = userName;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public String getFullName() {
+        return lastName + ", " + firstName;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this);
+    }
+}

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/AuthenticationDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/AuthenticationDao.java
@@ -1,0 +1,60 @@
+package com.cs6238.project2.s2dr.server.config.authentication;
+
+import com.cs6238.project2.s2dr.server.app.exceptions.NoQueryResultsException;
+import com.cs6238.project2.s2dr.server.app.exceptions.TooManyQueryResultsException;
+import com.cs6238.project2.s2dr.server.app.objects.User;
+import com.cs6238.project2.s2dr.server.config.GuiceServletConfig;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class AuthenticationDao {
+
+    private static final Connection connection = GuiceServletConfig.injector.getInstance(Connection.class);
+
+    public static User getUser(String userName, String password)
+            throws SQLException, NoQueryResultsException, TooManyQueryResultsException {
+
+        String query =
+                "SELECT userId," +
+                "       firstName," +
+                "       lastName," +
+                "       userName" +
+                "  FROM s2dr.Users" +
+                " WHERE userName = (?)" +
+                "   AND password = (?)";
+
+        PreparedStatement ps = null;
+        try {
+            ps = connection.prepareStatement(query);
+
+            ps.setString(1, userName);
+            ps.setString(2, password);
+
+            ResultSet rs = ps.executeQuery();
+
+            if (!rs.next()) {
+                throw new NoQueryResultsException("No username/password combination matches the provided credentials");
+            }
+
+            User user = User.builder()
+                    .setUserId(rs.getInt(1))
+                    .setFirstName(rs.getString(2))
+                    .setLastName(rs.getString(3))
+                    .setUserName(rs.getString(4))
+                    .build();
+
+            if (rs.next()) {
+                throw new TooManyQueryResultsException("Two users configured with the same username/password combination");
+            }
+
+            return user;
+        } finally {
+            if (ps != null) {
+                ps.close();
+            }
+        }
+    }
+}

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthFilter.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthFilter.java
@@ -1,0 +1,54 @@
+package com.cs6238.project2.s2dr.server.config.authentication;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.web.filter.authc.AuthenticatingFilter;
+import org.apache.shiro.web.util.WebUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+public class UserAuthFilter extends AuthenticatingFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuthenticatingFilter.class);
+
+    @Override
+    protected AuthenticationToken createToken(ServletRequest request, ServletResponse response) throws Exception {
+        LOG.info("Creating Token");
+        return null;
+    }
+
+    @Override
+    protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
+        LOG.info("Checking if access allowed");
+
+        Subject currentUser = SecurityUtils.getSubject();
+
+        boolean isAllowed = currentUser.isAuthenticated();
+
+        if (isAllowed) {
+            LOG.info("Access allowed for subject {}", currentUser);
+        } else {
+            LOG.info("Access not allowed for subject {}", currentUser);
+        }
+
+        return isAllowed;
+    }
+
+    @Override
+    protected boolean onAccessDenied(ServletRequest request, ServletResponse response) throws Exception {
+        LOG.info("Access Denied");
+
+        // return status 401
+        WebUtils.toHttp(response)
+                .sendError(HttpServletResponse.SC_UNAUTHORIZED, "Please login to gain access.");
+
+        return false;
+    }
+}

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthRealm.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthRealm.java
@@ -1,0 +1,55 @@
+package com.cs6238.project2.s2dr.server.config.authentication;
+
+import com.cs6238.project2.s2dr.server.app.exceptions.NoQueryResultsException;
+import com.cs6238.project2.s2dr.server.app.exceptions.TooManyQueryResultsException;
+import com.cs6238.project2.s2dr.server.app.objects.User;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.SimpleAuthenticationInfo;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+
+public class UserAuthRealm extends AuthorizingRealm {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuthorizingRealm.class);
+
+    @Override
+    public boolean supports(AuthenticationToken token) {
+        LOG.info("Checking if AuthenticationToken is supported");
+        return token instanceof UsernamePasswordToken;
+    }
+
+    @Override
+    protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
+        return null;
+    }
+
+    @Override
+    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token) throws AuthenticationException {
+        LOG.info("Checking for Authentication Info");
+
+        UsernamePasswordToken usernamePasswordToken = (UsernamePasswordToken) token;
+
+        User user;
+        try {
+            user = AuthenticationDao.getUser(
+                    usernamePasswordToken.getUsername(), new String(usernamePasswordToken.getPassword()));
+
+        } catch (SQLException | NoQueryResultsException | TooManyQueryResultsException e) {
+            throw new AuthenticationException(
+                    "Unable to authenticate the user based on the given username/password combo", e);
+        }
+
+        LOG.info("Successfully authenticated {}", user);
+
+        return new SimpleAuthenticationInfo(
+                user, usernamePasswordToken.getCredentials(), this.getName());
+    }
+}

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthShiroModule.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthShiroModule.java
@@ -1,0 +1,25 @@
+package com.cs6238.project2.s2dr.server.config.authentication;
+
+import com.google.inject.Key;
+import com.google.inject.Singleton;
+import org.apache.shiro.guice.web.ShiroWebModule;
+
+import javax.servlet.ServletContext;
+
+public class UserAuthShiroModule extends ShiroWebModule {
+
+    public UserAuthShiroModule(ServletContext servletContext) {
+        super(servletContext);
+    }
+
+    @Override
+    protected void configureShiroWeb() {
+        bindRealm().to(UserAuthRealm.class);
+
+        // allow anonymous users to reach the login endpoint without authenticating
+        addFilterChain("/s2dr/login", ANON);
+
+        // filter all requests through the authorization filter
+        addFilterChain("/**", Key.get(UserAuthFilter.class));
+    }
+}

--- a/src/main/resources/s2dr.sql
+++ b/src/main/resources/s2dr.sql
@@ -13,11 +13,13 @@ CREATE TABLE s2dr.Users
   userId INT NOT NULL AUTO_INCREMENT,
   firstName VARCHAR (255) NOT NULL,
   lastName VARCHAR (255) NOT NULL,
+  userName VARCHAR (255) NOT NULL,
+  password VARCHAR (255) NOT NULL,
   PRIMARY KEY (userId)
 );
 
-INSERT INTO s2dr.Users (firstName, lastName) VALUES ('Michael', 'Puckett');
-INSERT INTO s2dr.Users (firstName, lastName) VALUES ('Evan', 'Stuart');
+INSERT INTO s2dr.Users (firstName, lastName, userName, password) VALUES ('Michael', 'Puckett', 'mpuckett', 'password');
+INSERT INTO s2dr.Users (firstName, lastName, userName, password) VALUES ('Evan', 'Stuart', 'estuart', 'password');
 
 CREATE TABLE s2dr.Documents
 (


### PR DESCRIPTION
- I added basic HTTPS support through the Gretty plugin. Our HTTPS
  support still needs a good deal of work, such as using one of our own
  certs (right now, Gretty creates a self signed cert that is used), and
  we also need to enable mutual auth. If you want to use HTTPS for now,
  you must use port `:8443` rather than the HTTP port `:8080` (regular
  HTTP is still supported for now).

- The main addition in this commit is being able to block all requests
  until a user authenticates. The user now must submit a login request
  before being able to access any resources. There is also a logout
  request that will invalidate the session.

Fixes #7 (partially...will open follow up tickets)
Fixes #9