### PR TITLE
37 - Change Document Id to be Document Name

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentDao.java
@@ -6,6 +6,7 @@ import com.cs6238.project2.s2dr.server.app.exceptions.TooManyQueryResultsExcepti
 import com.cs6238.project2.s2dr.server.app.exceptions.UnexpectedQueryResultsException;
 import com.cs6238.project2.s2dr.server.app.objects.DelegatePermissionParams;
 import com.cs6238.project2.s2dr.server.app.objects.DocumentDownload;
+import com.cs6238.project2.s2dr.server.app.objects.SecurityFlag;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +31,33 @@ public class DocumentDao {
         this.conn = conn;
     }
 
-    public int uploadDocument(File document, String documentName, String securityFlag)
+    public boolean documentExists(String documentName) throws SQLException {
+
+        String query =
+                "SELECT documentName" +
+                "  FROM s2dr.documents" +
+                " WHERE documentName = ?";
+
+        PreparedStatement ps = null;
+        try {
+            ps = conn.prepareStatement(query);
+
+            ps.setString(1, documentName);
+
+            ResultSet rs = ps.executeQuery();
+
+            return rs.next();
+        } finally {
+            if (ps != null) {
+                ps.close();
+            }
+        }
+
+    }
+
+    public void uploadDocument(File document, String documentName, SecurityFlag securityFlag)
             throws SQLException, FileNotFoundException, UnexpectedQueryResultsException {
+
         String query =
                 "INSERT INTO s2dr.Documents (documentName, contents, securityFlag) " +
                 "VALUES (?, ?, ?)";
@@ -42,27 +68,9 @@ public class DocumentDao {
 
             ps.setString(1, documentName);
             ps.setClob(2, new FileReader(document));
-            ps.setString(3, securityFlag);
+            ps.setString(3, securityFlag.name());
 
             ps.executeUpdate();
-
-            ResultSet rs = ps.getGeneratedKeys();
-
-            if (!rs.next()) {
-                // no results were found when we were expecting one
-                throw new NoQueryResultsException(
-                        String.format("Was expecting at least one result from query: %s", query));
-            }
-
-            int newDocumentId = rs.getInt(1);
-
-            if (rs.next()) {
-                // multiple results were returned when we only expected one
-                throw new TooManyQueryResultsException(
-                        String.format("Was expecting only a single result from query: %s", query));
-            }
-
-            return newDocumentId;
 
         } finally {
             if (ps != null) {
@@ -71,28 +79,52 @@ public class DocumentDao {
         }
     }
 
-    public DocumentDownload downloadDocument(int documentId)
+    public void overwriteDocument(String documentName, File document, SecurityFlag securityFlag)
+            throws SQLException, FileNotFoundException {
+
+        String query =
+                "UPDATE s2dr.Documents" +
+                "   SET contents       = ?," +
+                "       securityFlag   = ?" +
+                " WHERE documentName = ?";
+
+        PreparedStatement ps = null;
+        try {
+            ps = conn.prepareCall(query);
+
+            ps.setClob(1, new FileReader(document));
+            ps.setString(2, securityFlag.name());
+            ps.setString(3, documentName);
+
+            ps.executeUpdate();
+        } finally {
+            if (ps != null) {
+                ps.close();
+            }
+        }
+    }
+
+    public DocumentDownload downloadDocument(String documentName)
             throws SQLException, DocumentNotFoundException, UnexpectedQueryResultsException {
         String query =
                 "SELECT * " +
                 "FROM s2dr.Documents " +
-                "WHERE documentId = ?";
+                "WHERE documentName = ?";
 
         PreparedStatement ps = null;
         try {
             ps = conn.prepareStatement(query);
 
-            ps.setInt(1, documentId);
+            ps.setString(1, documentName);
 
             ResultSet rs = ps.executeQuery();
 
             if (!rs.next()) {
-                // no documents matched the given documentId
+                // no documents matched the given document name
                 throw new DocumentNotFoundException();
             }
 
             DocumentDownload download = DocumentDownload.builder()
-                    .setDocumentId(rs.getInt("documentId"))
                     .setDocumentName(rs.getString("documentName"))
                     .setContents(rs.getClob("contents").getAsciiStream())
                     .build();
@@ -112,17 +144,17 @@ public class DocumentDao {
         }
     }
 
-    public void delegatePermissions(int documentId, DelegatePermissionParams delegateParams) throws SQLException {
+    public void delegatePermissions(String documentName, DelegatePermissionParams delegateParams) throws SQLException {
         String query =
                 "INSERT INTO s2dr.DocumentPermissions" +
-                "   (documentId, userId, permission, canPropogate)" +
+                "   (documentName, userId, permission, canPropogate)" +
                 "VALUES (?, ?, ?, ?)";
 
         PreparedStatement ps = null;
         try {
             ps = conn.prepareStatement(query);
 
-            ps.setInt(1, documentId);
+            ps.setString(1, documentName);
             ps.setInt(2, delegateParams.getUserId());
             ps.setString(3, delegateParams.getPermission().toString());
             ps.setBoolean(4, delegateParams.getCanPropogate());
@@ -137,22 +169,22 @@ public class DocumentDao {
     }
 
 
-    public void deleteDocument(int documentId) throws SQLException {
+    public void deleteDocument(String documentName) throws SQLException, NoQueryResultsException {
         Integer clobLength;
         //This query gets the length of the current clob
         String sizeQuery =
                 "SELECT * " +
                 "FROM s2dr.Documents " +
-                "WHERE documentId = (?)";
+                "WHERE documentName = (?)";
         PreparedStatement ps1 = null;
         try {
             ps1 = conn.prepareStatement(sizeQuery);
-            ps1.setInt(1, documentId);
+            ps1.setString(1, documentName);
             ResultSet rs = ps1.executeQuery();
 
             if (!rs.next()) {
-                // no documents matched the given documentId
-                throw new SQLException();
+                // no documents matched the given documentName
+                throw new NoQueryResultsException("No documents matched the given document name");
             }
             //get clob size
             clobLength = rs.getClob("contents").getSubString((long)1, (int)(rs.getClob("contents").length())).length() - 1;
@@ -167,14 +199,14 @@ public class DocumentDao {
         String zeroQuery =
                 "UPDATE s2dr.Documents " +
                 "SET contents = (?) " +
-                "WHERE documentID = (?)";
+                "WHERE documentName = (?)";
 
         PreparedStatement ps2 = null;
         try {
             ps2 = conn.prepareStatement(zeroQuery);
 
             ps2.setString(1, zeroClob);
-            ps2.setInt(2, documentId);
+            ps2.setString(2, documentName);
             ps2.executeUpdate();
 
         } finally {
@@ -187,12 +219,12 @@ public class DocumentDao {
         String query =
                 "DELETE " +
                 "FROM s2dr.Documents " +
-                "WHERE documentId = (?)";
+                "WHERE documentName = (?)";
 
         PreparedStatement ps3 = null;
         try {
             ps3 = conn.prepareStatement(query);
-            ps3.setInt(1, documentId);
+            ps3.setString(1, documentName);
 
             ps3.executeUpdate();
         } finally {
@@ -202,16 +234,16 @@ public class DocumentDao {
         }
     }
 
-    public void deleteAllDocumentPermissions(int documentId) throws SQLException {
+    public void deleteAllDocumentPermissions(String documentName) throws SQLException {
         String query =
                 "DELETE" +
                 "  FROM s2dr.DocumentPermissions" +
-                " WHERE documentId = ?";
+                " WHERE documentName = ?";
 
         PreparedStatement ps = null;
         try {
             ps = conn.prepareStatement(query);
-            ps.setInt(1, documentId);
+            ps.setString(1, documentName);
             ps.executeUpdate();
         } finally {
             if (ps != null) {

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentService.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentService.java
@@ -1,11 +1,13 @@
 package com.cs6238.project2.s2dr.server.app;
 
 import com.cs6238.project2.s2dr.server.app.exceptions.DocumentNotFoundException;
+import com.cs6238.project2.s2dr.server.app.exceptions.NoQueryResultsException;
 import com.cs6238.project2.s2dr.server.app.exceptions.UnexpectedQueryResultsException;
 import com.cs6238.project2.s2dr.server.app.objects.CurrentUser;
 import com.cs6238.project2.s2dr.server.app.objects.DelegatePermissionParams;
 import com.cs6238.project2.s2dr.server.app.objects.DocumentDownload;
 import com.cs6238.project2.s2dr.server.app.objects.DocumentPermission;
+import com.cs6238.project2.s2dr.server.app.objects.SecurityFlag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,38 +32,42 @@ public class DocumentService {
         this.documentDao = documentDao;
     }
 
-    public int uploadDocument(File document, String documentName, String securityFlag)
+    public void uploadDocument(File document, String documentName, SecurityFlag securityFlag)
             throws SQLException, FileNotFoundException, UnexpectedQueryResultsException {
 
-        int documentId = documentDao.uploadDocument(document, documentName, securityFlag);
+        if (!documentDao.documentExists(documentName)) {
+            documentDao.uploadDocument(document, documentName, securityFlag);
+        } else {
+
+            // TODO #6 need to check for write permission
+            documentDao.overwriteDocument(documentName, document, securityFlag);
+        }
 
         int currentUserId = currentUser.getCurrentUser().getUserId();
 
         // when a user uploads a new document, we add an "Owner" permission for that user.
         // TODO once we add the "time" parameter, this should add an "unlimited" time for the uploader
-        documentDao.delegatePermissions(documentId,
+        documentDao.delegatePermissions(documentName,
                 new DelegatePermissionParams(DocumentPermission.OWNER, currentUserId, true));
-
-        return documentId;
     }
 
-    public DocumentDownload downloadDocument(int documentId)
+    public DocumentDownload downloadDocument(String documentName)
             throws SQLException, DocumentNotFoundException, UnexpectedQueryResultsException {
 
-        return documentDao.downloadDocument(documentId);
+        return documentDao.downloadDocument(documentName);
     }
 
-    public void delegatePermissions(int documentId, DelegatePermissionParams delegateParams) throws SQLException {
-        documentDao.delegatePermissions(documentId, delegateParams);
+    public void delegatePermissions(String documentName, DelegatePermissionParams delegateParams) throws SQLException {
+        documentDao.delegatePermissions(documentName, delegateParams);
     }
 
-    public void deleteDocument(int documentId) throws SQLException {
+    public void deleteDocument(String documentName) throws SQLException, NoQueryResultsException {
 
         // delete all permissions for the document before deleting the document
-        LOG.info("Deleting all permissions for document: {}", documentId);
-        documentDao.deleteAllDocumentPermissions(documentId);
+        LOG.info("Deleting all permissions for document: {}", documentName);
+        documentDao.deleteAllDocumentPermissions(documentName);
 
-        LOG.info("Performing safe delete on document: {}", documentId);
-        documentDao.deleteDocument(documentId);
+        LOG.info("Performing safe delete on document: {}", documentName);
+        documentDao.deleteDocument(documentName);
     }
 }

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DocumentDownload.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DocumentDownload.java
@@ -11,14 +11,8 @@ import static java.util.Objects.requireNonNull;
 public class DocumentDownload {
 
     public static class Builder {
-        private int documentId;
         private String documentName;
         private InputStream contents;
-
-        public Builder setDocumentId(int documentId) {
-            this.documentId = documentId;
-            return this;
-        }
 
         public Builder setDocumentName(String documentName) {
             this.documentName = documentName;
@@ -32,7 +26,6 @@ public class DocumentDownload {
 
         public DocumentDownload build() {
             return new DocumentDownload(
-                    documentId,
                     documentName,
                     contents);
         }
@@ -42,22 +35,15 @@ public class DocumentDownload {
         return new Builder();
     }
 
-    private final int documentId;
     private final String documentName;
     private final InputStream contents;
 
     private DocumentDownload(
-            int documentId,
             String documentName,
             InputStream contents) {
 
-        this.documentId = requireNonNull(documentId);
         this.documentName = requireNonNull(documentName);
         this.contents = requireNonNull(contents);
-    }
-
-    public int getDocumentId() {
-        return documentId;
     }
 
     public String getDocumentName() {

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/SecurityFlag.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/SecurityFlag.java
@@ -1,0 +1,7 @@
+package com.cs6238.project2.s2dr.server.app.objects;
+
+public enum SecurityFlag {
+    CONFIDENTIALITY,
+    INTEGRITY,
+    NONE
+}

--- a/src/main/resources/s2dr.sql
+++ b/src/main/resources/s2dr.sql
@@ -18,21 +18,20 @@ CREATE TABLE s2dr.Users
 
 CREATE TABLE s2dr.Documents
 (
-  documentId INT NOT NULL AUTO_INCREMENT,
   documentName VARCHAR (255) NOT NULL,
   contents CLOB NOT NULL,
   securityFlag VARCHAR (255) NOT NULL,
   CONSTRAINT check_security CHECK (securityFlag IN ('NONE', 'INTEGRITY', 'CONFIDENTIALITY')),
-  PRIMARY KEY (documentId)
+  PRIMARY KEY (documentName)
 );
 
 CREATE TABLE s2dr.DocumentPermissions
 (
-  documentId INT NOT NULL,
+  documentName VARCHAR (255) NOT NULL,
   userId INT NOT NULL,
   permission VARCHAR (5) NOT NULL,
-  canPropogate VARCHAR(5) NOT NULL,
-  FOREIGN KEY (documentId) REFERENCES s2dr.Documents(documentId),
+  canPropogate VARCHAR (5) NOT NULL,
+  FOREIGN KEY (documentName) REFERENCES s2dr.Documents(documentName),
   FOREIGN KEY (userId) REFERENCES s2dr.Users(userId)
 );
 -- TODO constrain DocumentPermissions.permission to be only "READ", "WRITE", "BOTH", or "OWNER"


### PR DESCRIPTION
Updated the document table in the database to use the document name as
the document id. This was done to make fulfilling the project
requirements easier (regarding a question about the scenario where the
document exists when uploading..."If you have the permission to write,
then overwrite it."). All Java code related to the document id/name was
updated to work with this change too.

Fixes #37