### PR TITLE
41 - Parse Subject Common Name

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/app/LoginDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/LoginDao.java
@@ -26,7 +26,7 @@ public class LoginDao {
         try {
             ps = connection.prepareStatement(query);
 
-            ps.setString(1, token.getX500Principal().getName());
+            ps.setString(1, token.getSubjectCommonName());
             ps.setBytes(2, token.getSignature());
 
             ps.executeUpdate();

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/AuthenticationDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/AuthenticationDao.java
@@ -28,7 +28,7 @@ public class AuthenticationDao {
         try {
             ps = connection.prepareStatement(query);
 
-            ps.setString(1, token.getX500Principal().getName());
+            ps.setString(1, token.getSubjectCommonName());
             ps.setBytes(2, token.getSignature());
 
             ResultSet rs = ps.executeQuery();

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthRealm.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthRealm.java
@@ -23,7 +23,6 @@ public class UserAuthRealm extends AuthorizingRealm {
 
     @Override
     public boolean supports(AuthenticationToken token) {
-        LOG.info("Checking if AuthenticationToken is supported");
         return token instanceof X509Token;
     }
 
@@ -34,9 +33,8 @@ public class UserAuthRealm extends AuthorizingRealm {
 
     @Override
     protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token) throws AuthenticationException {
-        LOG.info("Checking for Authentication Info");
-
         X509Token x509Token = (X509Token) token;
+        LOG.info("Checking for authentication info using token {}", token);
 
         User user;
         try {

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/X509Token.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/X509Token.java
@@ -1,18 +1,41 @@
 package com.cs6238.project2.s2dr.server.config.authentication;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.shiro.authc.AuthenticationToken;
 
 import javax.security.auth.x500.X500Principal;
 
-// TODO provide access to the principal CN that can be used as the username
 public class X509Token implements AuthenticationToken {
 
-    private X500Principal principal;
-    private byte[] signature;
+    private final X500Principal principal;
+    private final byte[] signature;
 
     public X509Token(X500Principal principal, byte[] signature) {
         this.principal = principal;
         this.signature = signature;
+    }
+
+    public byte[] getSignature() {
+        return signature;
+    }
+
+    public X500Principal getX500Principal() {
+        return principal;
+    }
+
+    public String getSubjectCommonName() {
+        // `principal.getName` returns the entire subject section of the cert smashed into
+        // a single String
+        String subjectName = principal.getName();
+
+        // very naive parsing to get the common name. This would never fly in the "real world" :)
+        subjectName = subjectName
+                .substring(subjectName.indexOf("CN="), subjectName.indexOf(",OU=")) // parse out "CN=commonName"
+                .replaceAll("CN=", ""); // remove the "CN=" part
+
+        return subjectName;
     }
 
     @Override
@@ -25,11 +48,19 @@ public class X509Token implements AuthenticationToken {
         return getSignature();
     }
 
-    public byte[] getSignature() {
-        return signature;
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
     }
 
-    public X500Principal getX500Principal() {
-        return principal;
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "X509Token=[subjectName=%s]", getSubjectCommonName());
     }
 }


### PR DESCRIPTION
- The subjects common name is now parsed out and used as the username.
  The parsing is a very naive use of substring and replace. If "CN=" or
  ",OU=" is used in any of the subject information, then we're screwed.
  It's a school project so we should be fine...

Fixes #41