### PR TITLE
17 - Add Time Parameter To Document Permissions

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentDao.java
@@ -19,6 +19,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 
 public class DocumentDao {
 
@@ -151,8 +152,8 @@ public class DocumentDao {
     public void delegatePermissions(String documentName, DelegatePermissionParams delegateParams) throws SQLException {
         String query =
                 "INSERT INTO s2dr.DocumentPermissions" +
-                "   (documentName, userId, permission, canPropogate)" +
-                "VALUES (?, ?, ?, ?)";
+                "   (documentName, userId, permission, timeLimit, canPropogate)" +
+                "VALUES (?, ?, ?, ?, ?)";
 
         PreparedStatement ps = null;
         try {
@@ -161,7 +162,14 @@ public class DocumentDao {
             ps.setString(1, documentName);
             ps.setInt(2, delegateParams.getUserId());
             ps.setString(3, delegateParams.getPermission().toString());
-            ps.setBoolean(4, delegateParams.getCanPropogate());
+
+            Timestamp timeLimit = null;
+            if (delegateParams.getTimeLimitMillis().isPresent()) {
+                timeLimit = new Timestamp(System.currentTimeMillis() + delegateParams.getTimeLimitMillis().get());
+            }
+            ps.setTimestamp(4, timeLimit);
+
+            ps.setBoolean(5, delegateParams.getCanPropogate());
 
             ps.executeUpdate();
 

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentService.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentService.java
@@ -6,7 +6,6 @@ import com.cs6238.project2.s2dr.server.app.exceptions.UnexpectedQueryResultsExce
 import com.cs6238.project2.s2dr.server.app.objects.CurrentUser;
 import com.cs6238.project2.s2dr.server.app.objects.DelegatePermissionParams;
 import com.cs6238.project2.s2dr.server.app.objects.DocumentDownload;
-import com.cs6238.project2.s2dr.server.app.objects.DocumentPermission;
 import com.cs6238.project2.s2dr.server.app.objects.SecurityFlag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +37,6 @@ public class DocumentService {
         if (!documentDao.documentExists(documentName)) {
             documentDao.uploadDocument(document, documentName, securityFlag);
         } else {
-
             // TODO #6 need to check for write permission
             documentDao.overwriteDocument(documentName, document, securityFlag);
         }
@@ -46,9 +44,8 @@ public class DocumentService {
         int currentUserId = currentUser.getCurrentUser().getUserId();
 
         // when a user uploads a new document, we add an "Owner" permission for that user.
-        // TODO once we add the "time" parameter, this should add an "unlimited" time for the uploader
-        documentDao.delegatePermissions(documentName,
-                new DelegatePermissionParams(DocumentPermission.OWNER, currentUserId, true));
+        documentDao.delegatePermissions(
+                documentName, DelegatePermissionParams.getUploaderPermissions(currentUserId));
     }
 
     public DocumentDownload downloadDocument(String documentName)

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DelegatePermissionParams.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DelegatePermissionParams.java
@@ -4,11 +4,13 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-// TODO add a permission time limit param
+import java.util.Optional;
+
 public class DelegatePermissionParams {
 
     private DocumentPermission permission;
     private int userId;
+    private Long timeLimitMillis;
     private boolean canPropogate;
 
     @SuppressWarnings("unused")
@@ -18,10 +20,12 @@ public class DelegatePermissionParams {
     public DelegatePermissionParams(
             DocumentPermission permission,
             int userId,
+            Long timeLimitMillis,
             boolean canPropogate) {
 
         this.permission = permission;
         this.userId = userId;
+        this.timeLimitMillis = timeLimitMillis;
         this.canPropogate = canPropogate;
     }
 
@@ -33,8 +37,20 @@ public class DelegatePermissionParams {
         return userId;
     }
 
+    public Optional<Long> getTimeLimitMillis() {
+        return Optional.ofNullable(timeLimitMillis);
+    }
+
     public boolean getCanPropogate() {
         return canPropogate;
+    }
+
+    public static DelegatePermissionParams getUploaderPermissions(int userId) {
+        return new DelegatePermissionParams(
+                DocumentPermission.OWNER,
+                userId,
+                null,
+                true);
     }
 
     @Override

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/X509Token.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/X509Token.java
@@ -2,7 +2,6 @@ package com.cs6238.project2.s2dr.server.config.authentication;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.shiro.authc.AuthenticationToken;
 
 import javax.security.auth.x500.X500Principal;

--- a/src/main/resources/s2dr.sql
+++ b/src/main/resources/s2dr.sql
@@ -30,6 +30,7 @@ CREATE TABLE s2dr.DocumentPermissions
   documentName VARCHAR (255) NOT NULL,
   userId INT NOT NULL,
   permission VARCHAR (5) NOT NULL,
+  timeLimit TIMESTAMP,
   canPropogate VARCHAR (5) NOT NULL,
   FOREIGN KEY (documentName) REFERENCES s2dr.Documents(documentName),
   FOREIGN KEY (userId) REFERENCES s2dr.Users(userId)


### PR DESCRIPTION
It is now possible to set a time limit on a delegated permission. To
set this from the client, you simply add a `timeLimitMillis` parameter
to the request body which should represent the length of time the
permission should be valid in milliseconds (i.e. if you are setting a
time limit of 30 seconds, then the request body param should be 30000).

The paramater is stored as a `TIMESTAMP` field in the database and is
nullable. A null value in this column represents an unlimited time
limit.

Fixes #17