### PR TITLE
44 - Handle Multiple SecurityFlag Params

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/app/RestEndpoint.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/RestEndpoint.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.cert.X509Certificate;
 import java.sql.SQLException;
+import java.util.Set;
 
 @Path("s2dr")
 public class RestEndpoint {
@@ -75,12 +76,12 @@ public class RestEndpoint {
     public Response uploadDocument(
             @FormDataParam("document") File document,
             @FormDataParam("documentName") String documentName,
-            @FormDataParam("securityFlag") String securityFlag)
+            @FormDataParam("securityFlag") Set<SecurityFlag> securityFlags)
             throws SQLException, FileNotFoundException, URISyntaxException, UnexpectedQueryResultsException {
 
         LOG.info("Uploading new document named: {}", documentName);
 
-        documentService.uploadDocument(document, documentName, SecurityFlag.valueOf(securityFlag));
+        documentService.uploadDocument(document, documentName, securityFlags);
 
         LOG.info("Successfully uploaded document");
 

--- a/src/main/resources/s2dr.sql
+++ b/src/main/resources/s2dr.sql
@@ -20,9 +20,16 @@ CREATE TABLE s2dr.Documents
 (
   documentName VARCHAR (255) NOT NULL,
   contents CLOB NOT NULL,
+  PRIMARY KEY (documentName)
+);
+
+CREATE TABLE s2dr.DocumentSecurity
+(
+  documentName VARCHAR (255) NOT NULL,
   securityFlag VARCHAR (255) NOT NULL,
   CONSTRAINT check_security CHECK (securityFlag IN ('NONE', 'INTEGRITY', 'CONFIDENTIALITY')),
-  PRIMARY KEY (documentName)
+  PRIMARY KEY (documentName, securityFlag),
+  FOREIGN KEY (documentName) REFERENCES s2dr.Documents(documentName)
 );
 
 CREATE TABLE s2dr.DocumentPermissions


### PR DESCRIPTION
Project Requirement 7.1 requires that the server be able to handle
multiple `SecurityFlag`s when uploading a document. This commit adds
that ability.

- Added a new table for `DocumentSecurity` in the database.
- Refactored the DAO for this new table.
- Updated the `s2dr/upload` REST endpoint to accept a
  `Set<SecurityFlag>` of security flags.

Fixes #44