### PR TITLE
38 - Change UserId to UserName

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentDao.java
@@ -180,7 +180,7 @@ public class DocumentDao {
     public void delegatePermissions(String documentName, DelegatePermissionParams delegateParams) throws SQLException {
         String query =
                 "INSERT INTO s2dr.DocumentPermissions" +
-                "   (documentName, userId, permission, timeLimit, canPropogate)" +
+                "   (documentName, userName, permission, timeLimit, canPropogate)" +
                 "VALUES (?, ?, ?, ?, ?)";
 
         PreparedStatement ps = null;
@@ -188,7 +188,7 @@ public class DocumentDao {
             ps = conn.prepareStatement(query);
 
             ps.setString(1, documentName);
-            ps.setInt(2, delegateParams.getUserId());
+            ps.setString(2, delegateParams.getUserName());
             ps.setString(3, delegateParams.getPermission().toString());
 
             Timestamp timeLimit = null;

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentService.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentService.java
@@ -52,18 +52,18 @@ public class DocumentService {
             documentDao.setDocumentSecurity(documentName, securityFlag);
         }
 
-        int currentUserId = currentUser.getCurrentUser().getUserId();
+        String currentUserName = currentUser.getUserName();
 
         // when a user uploads a new document, we add an "Owner" permission for that user.
-        LOG.info("Adding owner permission to document \"{}\" for user \"{}\"", documentName, currentUserId);
+        LOG.info("Adding owner permission to document \"{}\" for user \"{}\"", documentName, currentUserName);
         documentDao.delegatePermissions(
-                documentName, DelegatePermissionParams.getUploaderPermissions(currentUserId));
+                documentName, DelegatePermissionParams.getUploaderPermissions(currentUserName));
     }
 
     public DocumentDownload downloadDocument(String documentName)
             throws SQLException, DocumentNotFoundException, UnexpectedQueryResultsException {
 
-        LOG.info("User \"{}\" downloading document \"{}\"", currentUser.getCurrentUser().getUserId(), documentName);
+        LOG.info("User \"{}\" downloading document \"{}\"", currentUser.getUserName(), documentName);
         return documentDao.downloadDocument(documentName);
     }
 

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/CurrentUser.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/CurrentUser.java
@@ -12,4 +12,8 @@ public class CurrentUser {
     public User getCurrentUser() {
         return currentUser;
     }
+
+    public String getUserName() {
+        return currentUser.getUserName();
+    }
 }

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DelegatePermissionParams.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DelegatePermissionParams.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public class DelegatePermissionParams {
 
     private DocumentPermission permission;
-    private int userId;
+    private String userName;
     private Long timeLimitMillis;
     private boolean canPropogate;
 
@@ -19,12 +19,12 @@ public class DelegatePermissionParams {
 
     public DelegatePermissionParams(
             DocumentPermission permission,
-            int userId,
+            String userName,
             Long timeLimitMillis,
             boolean canPropogate) {
 
         this.permission = permission;
-        this.userId = userId;
+        this.userName = userName;
         this.timeLimitMillis = timeLimitMillis;
         this.canPropogate = canPropogate;
     }
@@ -33,8 +33,8 @@ public class DelegatePermissionParams {
         return permission;
     }
 
-    public int getUserId() {
-        return userId;
+    public String getUserName() {
+        return userName;
     }
 
     public Optional<Long> getTimeLimitMillis() {
@@ -45,10 +45,10 @@ public class DelegatePermissionParams {
         return canPropogate;
     }
 
-    public static DelegatePermissionParams getUploaderPermissions(int userId) {
+    public static DelegatePermissionParams getUploaderPermissions(String userName) {
         return new DelegatePermissionParams(
                 DocumentPermission.OWNER,
-                userId,
+                userName,
                 null,
                 true);
     }

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/User.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/User.java
@@ -11,13 +11,7 @@ public class User {
     }
 
     public static class Builder {
-        private int userId;
         private String userName;
-
-        public Builder setUserId(int userId) {
-            this.userId = userId;
-            return this;
-        }
 
         public Builder setUserName(String userName) {
             this.userName = userName;
@@ -25,25 +19,15 @@ public class User {
         }
 
         public User build() {
-            return new User(
-                    userId,
-                    userName);
+            return new User(userName);
         }
     }
 
-    private final int userId;
     private final String userName;
 
-    private User(
-            int userId,
-            String userName) {
+    private User(String userName) {
 
-        this.userId = userId;
         this.userName = userName;
-    }
-
-    public int getUserId() {
-        return userId;
     }
 
     public String getUserName() {

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/AuthenticationDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/AuthenticationDao.java
@@ -18,8 +18,7 @@ public class AuthenticationDao {
             throws SQLException, NoQueryResultsException, TooManyQueryResultsException {
 
         String query =
-                "SELECT userId," +
-                "       userName" +
+                "SELECT userName" +
                 "  FROM s2dr.Users" +
                 " WHERE userName = (?)" +
                 "   AND signature = (?)";
@@ -38,8 +37,7 @@ public class AuthenticationDao {
             }
 
             User user = User.builder()
-                    .setUserId(rs.getInt(1))
-                    .setUserName(rs.getString(2))
+                    .setUserName(rs.getString(1))
                     .build();
 
             if (rs.next()) {

--- a/src/main/resources/s2dr.sql
+++ b/src/main/resources/s2dr.sql
@@ -10,10 +10,9 @@ CREATE SCHEMA s2dr;
 -- Table that will hold "Users" of the system
 CREATE TABLE s2dr.Users
 (
-  userId INT NOT NULL AUTO_INCREMENT,
   userName VARCHAR (255) NOT NULL,
   signature BLOB NOT NULL,
-  PRIMARY KEY (userId)
+  PRIMARY KEY (userName)
 );
 
 CREATE TABLE s2dr.Documents
@@ -35,7 +34,7 @@ CREATE TABLE s2dr.DocumentSecurity
 CREATE TABLE s2dr.DocumentPermissions
 (
   documentName VARCHAR (255) NOT NULL,
-  userId INT NOT NULL,
+  userName VARCHAR(255) NOT NULL,
   permission VARCHAR (5) NOT NULL,
   CONSTRAINT check_permission CHECK (permission IN ('READ', 'WRITE', 'BOTH', 'OWNER')),
   timeLimit TIMESTAMP,


### PR DESCRIPTION
The project requirements allow for a user's GUID to be their username,
so this commit removes all uses of `userId` and replaces it by using the
`userName` as the GUID. This will make the project easier (though it
wouldn't cut it in the real world).

Fixes #38