### PR TITLE
6 - Check User Possesses Permission

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentService.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/DocumentService.java
@@ -3,9 +3,11 @@ package com.cs6238.project2.s2dr.server.app;
 import com.cs6238.project2.s2dr.server.app.exceptions.DocumentNotFoundException;
 import com.cs6238.project2.s2dr.server.app.exceptions.NoQueryResultsException;
 import com.cs6238.project2.s2dr.server.app.exceptions.UnexpectedQueryResultsException;
+import com.cs6238.project2.s2dr.server.app.exceptions.UserLacksPermissionException;
 import com.cs6238.project2.s2dr.server.app.objects.CurrentUser;
 import com.cs6238.project2.s2dr.server.app.objects.DelegatePermissionParams;
 import com.cs6238.project2.s2dr.server.app.objects.DocumentDownload;
+import com.cs6238.project2.s2dr.server.app.objects.DocumentPermission;
 import com.cs6238.project2.s2dr.server.app.objects.SecurityFlag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,14 +35,26 @@ public class DocumentService {
     }
 
     public void uploadDocument(File document, String documentName, Set<SecurityFlag> securityFlags)
-            throws SQLException, FileNotFoundException, UnexpectedQueryResultsException {
+            throws SQLException, FileNotFoundException, UnexpectedQueryResultsException, UserLacksPermissionException {
 
         if (!documentDao.documentExists(documentName)) {
-            LOG.info("Uploading new Document");
+            LOG.info("Uploading new document \"{}\"", documentName);
             documentDao.uploadDocument(document, documentName);
         } else {
+            // because the document already exists, we must check if the current user has WRITE permission
+            // before allowing them to overwrite the document.
+            LOG.info("Checking if user \"{}\" has proper permission to over-write document \"{}\"",
+                    currentUser.getUserName(), documentName);
+            if (!hasWritePermission(documentDao.getDocPermsForCurrentUser(documentName))) {
+
+                LOG.info("User \"{}\" lacks WRITE permission for document \"{}\"",
+                        currentUser.getUserName(), documentName);
+
+                throw new UserLacksPermissionException(
+                        "You must have the correct permission before writing to an existing file");
+            }
+
             LOG.info("Overwriting document");
-            // TODO #6 need to check for write permission
             documentDao.overwriteDocument(documentName, document);
 
             LOG.info("Removing current security flags");
@@ -61,9 +75,18 @@ public class DocumentService {
     }
 
     public DocumentDownload downloadDocument(String documentName)
-            throws SQLException, DocumentNotFoundException, UnexpectedQueryResultsException {
+            throws SQLException, DocumentNotFoundException, UnexpectedQueryResultsException, UserLacksPermissionException {
 
-        LOG.info("User \"{}\" downloading document \"{}\"", currentUser.getUserName(), documentName);
+        LOG.info("Checking if user \"{}\" has proper permission to check-out document \"{}\"",
+                currentUser.getUserName(), documentName);
+
+        // if the user doesn't have read permission, then we throw an exception
+        if (!hasReadPermission(documentDao.getDocPermsForCurrentUser(documentName))) {
+            LOG.info("User \"{}\" lacks READ permission for document \"{}\"", currentUser.getUserName(), documentName);
+            throw new UserLacksPermissionException("You must have the correct permission before checking-out a file");
+        }
+
+        LOG.info("User \"{}\" checking-out document \"{}\"", currentUser.getUserName(), documentName);
         return documentDao.downloadDocument(documentName);
     }
 
@@ -73,7 +96,16 @@ public class DocumentService {
         documentDao.delegatePermissions(documentName, delegateParams);
     }
 
-    public void deleteDocument(String documentName) throws SQLException, NoQueryResultsException {
+    public void deleteDocument(String documentName)
+            throws SQLException, NoQueryResultsException, UserLacksPermissionException {
+
+        LOG.info("Checking if user \"{}\" has proper permission to delete document \"{}\"",
+                currentUser.getUserName(), documentName);
+        // TODO does WRITE permission allow for deletion too?
+        if (!hasOwnerPermission(documentDao.getDocPermsForCurrentUser(documentName))) {
+            LOG.info("User \"{}\" must have a valid OWNER permission to delete a document", currentUser.getUserName());
+            throw new UserLacksPermissionException("Only a document's owner is allowed to delete a file.");
+        }
 
         // delete all permissions for the document before deleting the document
         LOG.info("Deleting all permissions for document \"{}\"", documentName);
@@ -84,5 +116,23 @@ public class DocumentService {
 
         LOG.info("Performing safe delete on document \"{}\"", documentName);
         documentDao.deleteDocument(documentName);
+
+        LOG.info("Successfully deleted document \"{}\"", documentName);
+    }
+
+    private boolean hasReadPermission(Set<DocumentPermission> permissions) {
+        return permissions.contains(DocumentPermission.READ)
+                || permissions.contains(DocumentPermission.BOTH)
+                || permissions.contains(DocumentPermission.OWNER);
+    }
+
+    private boolean hasWritePermission(Set<DocumentPermission> permissions) {
+        return permissions.contains(DocumentPermission.WRITE)
+                || permissions.contains(DocumentPermission.BOTH)
+                || permissions.contains(DocumentPermission.OWNER);
+    }
+
+    private boolean hasOwnerPermission(Set<DocumentPermission> permissions) {
+        return permissions.contains(DocumentPermission.OWNER);
     }
 }

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/exceptions/UserLacksPermissionException.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/exceptions/UserLacksPermissionException.java
@@ -1,0 +1,7 @@
+package com.cs6238.project2.s2dr.server.app.exceptions;
+
+public class UserLacksPermissionException extends Exception {
+    public UserLacksPermissionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/CurrentUser.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/CurrentUser.java
@@ -9,10 +9,6 @@ public class CurrentUser {
         this.currentUser = currentUser;
     }
 
-    public User getCurrentUser() {
-        return currentUser;
-    }
-
     public String getUserName() {
         return currentUser.getUserName();
     }

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthFilter.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthFilter.java
@@ -26,19 +26,8 @@ public class UserAuthFilter extends AuthenticatingFilter {
 
     @Override
     protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
-        LOG.info("Checking if access allowed");
-
         Subject currentUser = SecurityUtils.getSubject();
-
-        boolean isAllowed = currentUser.isAuthenticated();
-
-        if (isAllowed) {
-            LOG.info("Access allowed for subject {}", currentUser);
-        } else {
-            LOG.info("Access not allowed for subject {}", currentUser);
-        }
-
-        return isAllowed;
+        return currentUser.isAuthenticated();
     }
 
     @Override


### PR DESCRIPTION
When a user performed an action on a document, we were just blindly
allowing the action. This commit adds the functionality where we first
check if the user has the proper permission before reading, writing (not
including original upload), or deleting.

I also cleaned up some logging so it would be easier to follow what
actions were taking place.

Fixes #6