### PR TITLE
11 Document Signature/Verification Support

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/app/LoginDao.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/LoginDao.java
@@ -3,6 +3,7 @@ package com.cs6238.project2.s2dr.server.app;
 import com.cs6238.project2.s2dr.server.config.authentication.X509Token;
 
 import javax.inject.Inject;
+import java.security.spec.RSAPublicKeySpec;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -16,11 +17,11 @@ public class LoginDao {
         this.connection = connection;
     }
 
-    public void addNewUser(X509Token token) throws SQLException {
+    public void addNewUser(X509Token token, RSAPublicKeySpec publicKeySpec) throws SQLException {
         String query =
                 "INSERT" +
-                "  INTO s2dr.Users (userName, signature)" +
-                "VALUES (?, ?)";
+                "  INTO s2dr.Users (userName, signature, pubKeyModulus, pubKeyExponent)" +
+                "VALUES (?, ?, ?, ?)";
 
         PreparedStatement ps = null;
         try {
@@ -28,6 +29,8 @@ public class LoginDao {
 
             ps.setString(1, token.getSubjectCommonName());
             ps.setBytes(2, token.getSignature());
+            ps.setBytes(3, publicKeySpec.getModulus().toByteArray());
+            ps.setBytes(4, publicKeySpec.getPublicExponent().toByteArray());
 
             ps.executeUpdate();
         } finally {

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/LoginService.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/LoginService.java
@@ -4,13 +4,19 @@ import com.cs6238.project2.s2dr.server.config.authentication.X509Token;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.subject.Subject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.security.auth.x500.X500Principal;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
 import java.sql.SQLException;
 
 public class LoginService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoginService.class);
 
     private final LoginDao loginDao;
 
@@ -30,13 +36,18 @@ public class LoginService {
         try {
             currentUser.login(token);
         } catch (AuthenticationException e) {
-            addNewUser(token);
+            LOG.info("Unable to authenticate based on credentials {}.", token);
+
+            RSAPublicKey publicKey = (RSAPublicKey) certificate.getPublicKey();
+            addNewUser(token, new RSAPublicKeySpec(publicKey.getModulus(), publicKey.getPublicExponent()));
+
+            LOG.info("Added credentials {} as a new user. Will re-attempt login", token);
         }
 
         currentUser.login(token);
     }
 
-    public void addNewUser(X509Token token) throws SQLException {
-        loginDao.addNewUser(token);
+    public void addNewUser(X509Token token, RSAPublicKeySpec publicKeySpec) throws SQLException {
+        loginDao.addNewUser(token, publicKeySpec);
     }
 }

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/exceptions/DocumentIntegrityVerificationException.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/exceptions/DocumentIntegrityVerificationException.java
@@ -1,0 +1,3 @@
+package com.cs6238.project2.s2dr.server.app.exceptions;
+
+public class DocumentIntegrityVerificationException extends Exception {}

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DocumentDownload.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DocumentDownload.java
@@ -13,11 +13,18 @@ public class DocumentDownload {
 
     public static class Builder {
         private String documentName;
+        private String uploadUserName;
         private InputStream contents;
         private Optional<byte[]> encryptionKey = Optional.empty();
+        private Optional<byte[]> signature = Optional.empty();
 
         public Builder setDocumentName(String documentName) {
             this.documentName = documentName;
+            return this;
+        }
+
+        public Builder setUploadUserName(String uploadUserName) {
+            this.uploadUserName = uploadUserName;
             return this;
         }
 
@@ -31,11 +38,18 @@ public class DocumentDownload {
             return this;
         }
 
+        public Builder setSignature(Optional<byte[]> signature) {
+            this.signature = signature;
+            return this;
+        }
+
         public DocumentDownload build() {
             return new DocumentDownload(
                     documentName,
+                    uploadUserName,
                     contents,
-                    encryptionKey);
+                    encryptionKey,
+                    signature);
         }
     }
 
@@ -44,21 +58,31 @@ public class DocumentDownload {
     }
 
     private final String documentName;
+    private final String uploadUserName;
     private final InputStream contents;
     private final Optional<byte[]> encryptionKey;
+    private final Optional<byte[]> signature;
 
     private DocumentDownload(
             String documentName,
+            String uploadUserName,
             InputStream contents,
-            Optional<byte[]> encryptionKey) {
+            Optional<byte[]> encryptionKey,
+            Optional<byte[]> signature) {
 
         this.documentName = requireNonNull(documentName);
+        this.uploadUserName = requireNonNull(uploadUserName);
         this.contents = requireNonNull(contents);
         this.encryptionKey = encryptionKey;
+        this.signature = signature;
     }
 
     public String getDocumentName() {
         return documentName;
+    }
+
+    public String getUploadUserName() {
+        return uploadUserName;
     }
 
     public InputStream getContents() {
@@ -67,6 +91,10 @@ public class DocumentDownload {
 
     public Optional<byte[]> getEncryptionKey() {
         return encryptionKey;
+    }
+
+    public Optional<byte[]> getSignature() {
+        return signature;
     }
 
     @Override

--- a/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthRealm.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/config/authentication/UserAuthRealm.java
@@ -45,7 +45,7 @@ public class UserAuthRealm extends AuthorizingRealm {
                     "Unable to authenticate the user based on the given username/password combo", e);
         }
 
-        LOG.info("Successfully authenticated {}", user);
+        LOG.info("Successfully authenticated {}", user.getUserName());
 
         CurrentUser currentUser = GuiceServletConfig.injector.getInstance(CurrentUser.class);
         currentUser.setCurrentUser(user);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
 
     <logger name="server" level="TRACE"/>
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/main/resources/s2dr.sql
+++ b/src/main/resources/s2dr.sql
@@ -12,6 +12,8 @@ CREATE TABLE s2dr.Users
 (
   userName VARCHAR (255) NOT NULL,
   signature BLOB NOT NULL,
+  pubKeyModulus BLOB NOT NULL,
+  pubKeyExponent BLOB NOT NULL,
   PRIMARY KEY (userName)
 );
 
@@ -19,8 +21,11 @@ CREATE TABLE s2dr.Documents
 (
   documentName VARCHAR (255) NOT NULL,
   contents BLOB NOT NULL,
+  uploadUser VARCHAR(255) NOT NULL,
   encryptionKey BLOB,
-  PRIMARY KEY (documentName)
+  signature BLOB,
+  PRIMARY KEY (documentName),
+  FOREIGN KEY (uploadUser) REFERENCES s2dr.Users(userName)
 );
 
 CREATE TABLE s2dr.DocumentSecurity


### PR DESCRIPTION
Added support for the `INTEGRITY` security flag. When this is selected
for uploading a document, the client must include the RSA-SHA256
signature as a request body param, which will be stored alongside the
document in the database. When a user checks out a document containing
this security flag, the server will first verify the signature using the
RSA public key of the uploader before returning the document.
- A user's RSA modulus and RSA public exponent is now stored in the User
  table so that we can reconstruct the RSA public key when verify
  signatures.
- The document's RSA-SHA256 signature is stored alongside the database
  whenever the INTEGRITY security flag is chosen.
- Both the CONFIDENTIALITY and INTEGRITY flags can be set on an upload
  at the same time.

Fixes #11