### PR TITLE
53 Permission Override Support

### DIFF
--- a/src/main/java/com/cs6238/project2/s2dr/server/app/RestEndpoint.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/RestEndpoint.java
@@ -154,8 +154,6 @@ public class RestEndpoint {
     public Response delegate(@PathParam("documentName") String documentName,
                              DelegatePermissionParams delegateParams) throws SQLException, NoQueryResultsException {
 
-        LOG.info("Delegating permissions: {}, for document: {}", delegateParams, documentName);
-
         try {
             documentService.delegatePermissions(documentName, delegateParams);
         } catch (UserLacksPermissionException e) {

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DelegatePermissionParams.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DelegatePermissionParams.java
@@ -1,14 +1,17 @@
 package com.cs6238.project2.s2dr.server.app.objects;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
+import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 
 public class DelegatePermissionParams {
 
-    private DocumentPermission permission;
+    private Set<DocumentPermission> permissions;
     private String userName;
     private Long timeLimitMillis;
     private boolean canPropogate;
@@ -18,19 +21,19 @@ public class DelegatePermissionParams {
     public DelegatePermissionParams() {}
 
     public DelegatePermissionParams(
-            DocumentPermission permission,
+            Set<DocumentPermission> permissions,
             String userName,
             Long timeLimitMillis,
             boolean canPropogate) {
 
-        this.permission = permission;
+        this.permissions = permissions;
         this.userName = userName;
         this.timeLimitMillis = timeLimitMillis;
         this.canPropogate = canPropogate;
     }
 
-    public DocumentPermission getPermission() {
-        return permission;
+    public EnumSet<DocumentPermission> getPermissions() {
+        return EnumSet.copyOf(permissions);
     }
 
     public String getUserName() {
@@ -47,7 +50,7 @@ public class DelegatePermissionParams {
 
     public static DelegatePermissionParams getUploaderPermissions(String userName) {
         return new DelegatePermissionParams(
-                DocumentPermission.OWNER,
+                ImmutableSet.of(DocumentPermission.OWNER),
                 userName,
                 null,
                 true);

--- a/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DocumentPermission.java
+++ b/src/main/java/com/cs6238/project2/s2dr/server/app/objects/DocumentPermission.java
@@ -3,6 +3,5 @@ package com.cs6238.project2.s2dr.server.app.objects;
 public enum DocumentPermission {
     READ,
     WRITE,
-    BOTH,
     OWNER
 }

--- a/src/main/resources/s2dr.sql
+++ b/src/main/resources/s2dr.sql
@@ -42,10 +42,13 @@ CREATE TABLE s2dr.DocumentPermissions
   documentName VARCHAR (255) NOT NULL,
   userName VARCHAR(255) NOT NULL,
   permission VARCHAR (5) NOT NULL,
-  CONSTRAINT check_permission CHECK (permission IN ('READ', 'WRITE', 'BOTH', 'OWNER')),
+  CONSTRAINT check_permission CHECK (permission IN ('READ', 'WRITE', 'OWNER')),
   timeLimit TIMESTAMP,
   canPropogate VARCHAR (5) NOT NULL,
   CONSTRAINT check_bool CHECK (canPropogate IN ('TRUE', 'FALSE')),
   FOREIGN KEY (documentName) REFERENCES s2dr.Documents(documentName)
+  -- we cannot set FOREIGN KEY(documentName, userName, permission) because we don't
+    -- delete permissions that have expired based on time
+  -- we cannot have a foreign key for Users.userName because we allow "ALL"
 );
 


### PR DESCRIPTION
One of the questions answered in Piazza mentioned that a user should
have the ability to "revoke" a permission from a user. This required
that permission stored in the database (and are still valid from from a
time limit aspect) should be over-ridding when a user is re-delegated
that permission.

To make this easier, I removed the `BOTH` DocumentPermission. Now if we
want to delegate both read and write permission to a user, we must
submit `READ` and `WRITE`. The delegate permission endpoint was updated
so that the `permissions` request body parameter is now a list of
permissions so that multiple can be sent in the same request.

Fixes #53